### PR TITLE
fix: C# access to ResourceGroup properties through wrapper

### DIFF
--- a/addons/godot_resource_groups/csharp/ResourceGroup.cs
+++ b/addons/godot_resource_groups/csharp/ResourceGroup.cs
@@ -48,17 +48,17 @@ namespace GodotResourceGroups
         /// <summary>
         /// Returns all include patterns in this resource group.
         /// </summary>
-        public List<string> Includes => new(_wrapped.Call("get_includes").AsStringArray());
+        public List<string> Includes => new(_wrapped.Get("includes").AsStringArray());
 
         /// <summary>
         /// Returns all exclude patterns in this resource group.
         /// </summary>
-        public List<string> Excludes => new(_wrapped.Call("get_excludes").AsStringArray());
+        public List<string> Excludes => new(_wrapped.Get("excludes").AsStringArray());
 
         /// <summary>
         /// Returns all paths in this resource group.
         /// </summary>
-        public List<string> Paths => new(_wrapped.Call("get_paths").AsStringArray());
+        public List<string> Paths => new(_wrapped.Get("paths").AsStringArray());
 
         /// <summary>
         /// Loads all resources in this resource group.


### PR DESCRIPTION
This fixes non-existent method exceptions caused in the C# ResourceGroup wrapper when trying to access the Includes, Excludes and Paths properties.

Fixed Exception (analogue for the other named properties): 
Invalid call. Nonexistent function 'get_paths' in base 'Godot.Resource'.