### PR TITLE
Remove trailing forward slash

### DIFF
--- a/addons/godot_resource_groups/path_verifier.gd
+++ b/addons/godot_resource_groups/path_verifier.gd
@@ -36,7 +36,7 @@ func _compile_pattern(base_folder:String, pattern:String) -> RegEx:
 	# the pattern is anchored at the beginning and end of the string
 	# the pattern is case-sensitive
 
-	var regex = "^" + _escape_string(base_folder) + "/"
+	var regex = "^" + _escape_string(base_folder)
 	var i = 0
 	var len = pattern.length()
 


### PR DESCRIPTION
The trialing forward slash messes up the regex when the base_folder string already contains a trailing forward slash (which occurs when you use the folder icon next to the export to select a folder).