### PR TITLE
Rebuilding resources on request from another plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ if resource_group_plugin != null:
 
 **Important:**: Implemented only for GDScript
 
-**Important:**: It would not and **should not** work in exported game. `ResourceGroupsPlugin.instance` will return `null`
+**Important:**: It will not and **should not** work in exported game. `ResourceGroupsPlugin.instance` will return `null`
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,23 @@ Also check out the loading examples for [GDScript](godot_resource_groups_example
 
 There is also a variant `load_matching_in_background` which works similarly, but only loads a subset of the resources.
 
+## Using in plugins
+
+### Rebuilding resources on request from another plugin
+
+If you create resources using a custom plugin, you can trigger group rebuilding from that plugin using a signal:
+
+```gdscript
+var resource_group_plugin = ResourceGroupsPlugin.instance
+
+if resource_group_plugin != null:
+	resource_group_plugin.rebuild_resources.emit()
+```
+
+**Important:**: Implemented only for GDScript
+
+**Important:**: It would not and **should not** work in exported game. `ResourceGroupsPlugin.instance` will return `null`
+
 ## FAQ
 
 ### How do I select all but a few resources?

--- a/README.md
+++ b/README.md
@@ -189,18 +189,19 @@ There is also a variant `load_matching_in_background` which works similarly, but
 
 ### Rebuilding resources on request from another plugin
 
-If you create resources using a custom plugin, you can trigger group rebuilding from that plugin using a signal:
+If you create resources using editor scripting, you can trigger a rebuild of all resource groups from your plugin:
 
 ```gdscript
-var resource_group_plugin = ResourceGroupsPlugin.instance
-
-if resource_group_plugin != null:
-	resource_group_plugin.rebuild_resources.emit()
+ResourceGroupsPlugin.rebuild_resource_groups()
 ```
 
-**Important:**: Implemented only for GDScript
+Similarly from C#:
 
-**Important:**: It will not and **should not** work in exported game. `ResourceGroupsPlugin.instance` will return `null`
+```csharp
+ResourceGroupsPlugin.RebuildResourceGroups();
+```
+
+Please note, that this will only work in the editor. If you call this function at runtime it will print an error message and do nothing.
 
 ## FAQ
 

--- a/addons/godot_resource_groups/csharp/ResourceGroupsPlugin.cs
+++ b/addons/godot_resource_groups/csharp/ResourceGroupsPlugin.cs
@@ -1,0 +1,28 @@
+﻿using Godot;
+
+namespace GodotResourceGroups;
+
+public class ResourceGroupsPlugin
+{
+    /// <summary>
+    /// Rebuilds all resource groups. Useful if you have custom editor scripts that create or modify resources
+    /// and want to update the resource groups via script.
+    /// </summary>
+    public static void RebuildResourceGroups()
+    {
+        if (!Engine.IsEditorHint())
+		{
+			GD.PushError("ResourceGroupsPlugin.RebuildResourceGroups() can only be called inside of the editor.");
+			return;
+		}
+        
+        var plugin = Engine.GetSingleton("ResourceGroupsPlugin");
+        if (plugin == null)
+        {
+	        GD.PushError("Resource group plugin is not active, please check if it is enabled in the project settings.");
+	        return;
+        }
+
+        plugin.Call("_rebuild_resource_groups");
+    }
+}

--- a/addons/godot_resource_groups/godot_resource_groups.gd
+++ b/addons/godot_resource_groups/godot_resource_groups.gd
@@ -10,9 +10,6 @@ var _group_scanner: ResourceGroupScanner
 var _export_plugin: ResourceGroupsExportPlugin
 
 func _enter_tree():
-	if not Engine.is_editor_hint():
-		return
-	
 	# make the plugin singleton available to the rest of the engine
 	Engine.register_singleton("ResourceGroupsPlugin", self)
 	
@@ -37,9 +34,6 @@ func _enter_tree():
 
 
 func _exit_tree():
-	if not Engine.is_editor_hint():
-		return
-
 	Engine.unregister_singleton("ResourceGroupsPlugin")
 	remove_tool_menu_item("Rebuild project resource groups")
 	remove_export_plugin(_export_plugin)

--- a/addons/godot_resource_groups/godot_resource_groups.gd
+++ b/addons/godot_resource_groups/godot_resource_groups.gd
@@ -1,5 +1,6 @@
 @tool
 extends EditorPlugin
+class_name ResourceGroupsPlugin
 
 const ResourceScanner = preload("resource_scanner.gd")
 const ResourceGroupScanner = preload("resource_group_scanner.gd")
@@ -9,8 +10,14 @@ const REBUILD_SETTING: StringName = "godot_resource_groups/auto_rebuild"
 var _group_scanner: ResourceGroupScanner
 var _export_plugin: ResourceGroupsExportPlugin
 
+static var instance : EditorPlugin
+
+signal rebuild_resources
 
 func _enter_tree():
+	instance = self
+	_connect_signals()
+
 	add_tool_menu_item("Rebuild project resource groups", _rebuild_resource_groups)
 	_group_scanner = ResourceGroupScanner.new(get_editor_interface().get_resource_filesystem())
 	
@@ -32,8 +39,19 @@ func _enter_tree():
 
 
 func _exit_tree():
+	_disconnect_signals()
 	remove_tool_menu_item("Rebuild project resource groups")
 	remove_export_plugin(_export_plugin)
+	instance = null
+
+
+func _connect_signals():
+	rebuild_resources.connect(_rebuild_resource_groups)
+
+
+func _disconnect_signals():
+	if rebuild_resources.is_connected(_rebuild_resource_groups):
+		rebuild_resources.disconnect(_rebuild_resource_groups)
 
 
 func _build() -> bool:

--- a/addons/godot_resource_groups/godot_resource_groups.gd
+++ b/addons/godot_resource_groups/godot_resource_groups.gd
@@ -1,6 +1,5 @@
 @tool
 extends EditorPlugin
-class_name ResourceGroupsPlugin
 
 const ResourceScanner = preload("resource_scanner.gd")
 const ResourceGroupScanner = preload("resource_group_scanner.gd")
@@ -10,14 +9,13 @@ const REBUILD_SETTING: StringName = "godot_resource_groups/auto_rebuild"
 var _group_scanner: ResourceGroupScanner
 var _export_plugin: ResourceGroupsExportPlugin
 
-static var instance : EditorPlugin
-
-signal rebuild_resources
-
 func _enter_tree():
-	instance = self
-	_connect_signals()
-
+	if not Engine.is_editor_hint():
+		return
+	
+	# make the plugin singleton available to the rest of the engine
+	Engine.register_singleton("ResourceGroupsPlugin", self)
+	
 	add_tool_menu_item("Rebuild project resource groups", _rebuild_resource_groups)
 	_group_scanner = ResourceGroupScanner.new(get_editor_interface().get_resource_filesystem())
 	
@@ -39,19 +37,12 @@ func _enter_tree():
 
 
 func _exit_tree():
-	_disconnect_signals()
+	if not Engine.is_editor_hint():
+		return
+
+	Engine.unregister_singleton("ResourceGroupsPlugin")
 	remove_tool_menu_item("Rebuild project resource groups")
 	remove_export_plugin(_export_plugin)
-	instance = null
-
-
-func _connect_signals():
-	rebuild_resources.connect(_rebuild_resource_groups)
-
-
-func _disconnect_signals():
-	if rebuild_resources.is_connected(_rebuild_resource_groups):
-		rebuild_resources.disconnect(_rebuild_resource_groups)
 
 
 func _build() -> bool:

--- a/addons/godot_resource_groups/resource_groups_plugin.gd
+++ b/addons/godot_resource_groups/resource_groups_plugin.gd
@@ -1,0 +1,14 @@
+﻿class_name ResourceGroupsPlugin
+
+## Rebuilds all resource groups. Useful if you have custom editor scripts that create or modify resources
+## and want to update the resource groups via script.
+static func rebuild_resource_groups():
+	if not Engine.is_editor_hint():
+		push_error("ResourceGroupsPlugin.rebuild_resource_groups() can only be called inside of the editor.")
+		return
+
+	var plugin = Engine.get_singleton("ResourceGroupsPlugin")
+	if not is_instance_valid(plugin):
+		push_error("Resource group plugin is not active, please check if it is enabled in the project settings.")
+		return
+	plugin._rebuild_resource_groups()


### PR DESCRIPTION
Hi.

In my project, I create some resources through a custom plugin and realized that it is inconvenient to manually call the resource rebuild through the menu.
That's why I added a signal to the plugin. I think it's a convenient and useful feature.

I don't really like the implementation via `static var instance`, but creating an event bus and registering through `Engine.register_singleton` seems redundant and not so convenient

Really like the plugin, thanks for your work.